### PR TITLE
.gitatributes: Specify file language as Adblock Filter List

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+uBlacklist.txt linguist-language=AdBlock linguist-detectable


### PR DESCRIPTION
Create .gitattributes file to specify uBlacklist.txt is an AdBlock Filter List. Adds syntax highlighting when viewing filter file, and lists AdBlock Filter List under languages in GitHub.

See https://github.com/github-linguist/linguist/blob/main/docs/overrides.md

Also done in EasyList: https://github.com/easylist/easylist/blob/master/.gitattributes

- [x] I've read [the contribution policy](https://github.com/arosh/ublacklist-stackoverflow-translation/blob/master/CONTRIBUTING.md)
- [ ] I've updated domain-list.yml with evidence that this site is a low-quality mirror
